### PR TITLE
Create initial version of the web api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ First attempt at building web api using Go
 ## Packages
 The application uses 
 - [conf](https://pkg.go.dev/github.com/ardanlabs/conf) from Ardan Labs
+- [httptreemux]("github.com/dimfeld/httptreemux/v5") from Daniel Imfeld 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # learn-go-webapi
-First attempt at building web api
+First attempt at building web api using Go
+
+## Packages
+The application uses 
+- [conf](https://pkg.go.dev/github.com/ardanlabs/conf) from Ardan Labs

--- a/app/products-api/handlers/handlers.go
+++ b/app/products-api/handlers/handlers.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"github.com/dimfeld/httptreemux/v5"
 	"net/http"
 )
 
 func API() http.Handler {
-	api := http.NewServeMux()
-	api.HandleFunc("/status/ping", statusPingHandler)
-	return api
+	router := httptreemux.NewContextMux()
+	group := router.NewGroup("/api")
+	group.GET("/status/ping", statusPingHandler)
+	return router
 }

--- a/app/products-api/handlers/handlers.go
+++ b/app/products-api/handlers/handlers.go
@@ -1,20 +1,11 @@
 package handlers
 
 import (
-	"fmt"
-	"log"
 	"net/http"
-	"os"
-	"time"
 )
 
-func API(buildNo string, shutdown chan os.Signal, log *log.Logger) http.Handler {
+func API() http.Handler {
 	api := http.NewServeMux()
-	api.HandleFunc("/status/ping", pingHandler)
+	api.HandleFunc("/status/ping", statusPingHandler)
 	return api
-}
-
-func pingHandler(w http.ResponseWriter, r *http.Request) {
-	pingResponse := fmt.Sprintf("pong: %v", time.Now().UTC().Format(time.RFC3339))
-	w.Write([]byte(pingResponse))
 }

--- a/app/products-api/handlers/handlers.go
+++ b/app/products-api/handlers/handlers.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+func API(buildNo string, shutdown chan os.Signal, log *log.Logger) http.Handler {
+	api := http.NewServeMux()
+	api.HandleFunc("/status/ping", pingHandler)
+	return api
+}
+
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	pingResponse := fmt.Sprintf("pong: %v", time.Now().UTC().Format(time.RFC3339))
+	w.Write([]byte(pingResponse))
+}

--- a/app/products-api/handlers/status.go
+++ b/app/products-api/handlers/status.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func statusPingHandler(w http.ResponseWriter, r *http.Request) {
+	pingResponse := fmt.Sprintf("pong: %v", time.Now().UTC().Format(time.RFC3339))
+	w.Write([]byte(pingResponse))
+}

--- a/app/products-api/handlers/status.go
+++ b/app/products-api/handlers/status.go
@@ -2,11 +2,18 @@ package handlers
 
 import (
 	"fmt"
+	"github.com/dimfeld/httptreemux/v5"
 	"net/http"
 	"time"
 )
 
 func statusPingHandler(w http.ResponseWriter, r *http.Request) {
-	pingResponse := fmt.Sprintf("pong: %v", time.Now().UTC().Format(time.RFC3339))
+	ctxData := httptreemux.ContextData(r.Context())
+	routePath := ctxData.Route()
+
+	pingResponse := fmt.Sprintf("uri: %s - pong: %v",
+		routePath,
+		time.Now().UTC().Format(time.RFC3339))
+
 	w.Write([]byte(pingResponse))
 }

--- a/app/products-api/main.go
+++ b/app/products-api/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("products-api")
+}

--- a/app/products-api/main.go
+++ b/app/products-api/main.go
@@ -1,5 +1,65 @@
 package main
 
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ardanlabs/conf"
+	"github.com/pkg/errors"
+)
+
+const (
+	ApiName = "PRODUCTS"
+)
+
+// version number of the program - to be set in part of ci/cd pipeline
+var build = "develop"
+
 func main() {
-	println("products-api")
+	log := log.New(os.Stdout, "PRODUCTS : ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+
+	if err := run(log); err != nil {
+		log.Println("main: error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(log *log.Logger) error {
+
+	// ===
+	// Configuration
+	var cfg struct {
+		conf.Version
+		Web struct {
+			APIHost         string `conf:"default:0.0.0.0:3000"`
+			ReadTimeout     string `conf:"default:5s"`
+			WriteTimeout    string `conf:"default:5s"`
+			ShutdownTimeout string `conf:"default:5s"`
+		}
+	}
+	cfg.SVN = build
+	cfg.Version.Desc = "products api"
+
+	if err := conf.Parse(os.Args[1:], ApiName, &cfg); err != nil {
+		switch err {
+		case conf.ErrHelpWanted:
+			usage, err := conf.Usage(ApiName, &cfg)
+			if err != nil {
+				return errors.Wrap(err, "generating config usage")
+			}
+			fmt.Println(usage)
+			return nil
+		case conf.ErrVersionWanted:
+			version, err := conf.VersionString(ApiName, &cfg)
+			if err != nil {
+				return errors.Wrap(err, "generating config version")
+			}
+			fmt.Println(version)
+			return nil
+		}
+		return errors.Wrap(err, "parsing config")
+	}
+
+	return nil
 }

--- a/app/products-api/main.go
+++ b/app/products-api/main.go
@@ -91,7 +91,7 @@ func run(log *log.Logger) error {
 
 	api := http.Server{
 		Addr:         cfg.Web.APIHost,
-		Handler:      handlers.API(build, shutdown, log),
+		Handler:      handlers.API(),
 		ReadTimeout:  cfg.Web.ReadTimeout,
 		WriteTimeout: cfg.Web.WriteTimeout,
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/stevejxn/learn-go-webapi
 
 go 1.16
+
+require (
+	github.com/ardanlabs/conf v1.4.0
+	github.com/pkg/errors v0.9.1
+)

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/ardanlabs/conf v1.4.0
+	github.com/dimfeld/httptreemux/v5 v5.3.0 // indirect
 	github.com/pkg/errors v0.9.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/stevejxn/learn-go-webapi
+
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/ardanlabs/conf v1.4.0 h1:Nzi1Z5TBlwdNNYTSjfm26NL3C8kbVCZhEnJ7kiyONdY=
+github.com/ardanlabs/conf v1.4.0/go.mod h1:ILsMo9dMqYzCxDjDXTiwMI0IgxOJd0MOiucbQY2wlJw=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ardanlabs/conf v1.4.0 h1:Nzi1Z5TBlwdNNYTSjfm26NL3C8kbVCZhEnJ7kiyONdY=
 github.com/ardanlabs/conf v1.4.0/go.mod h1:ILsMo9dMqYzCxDjDXTiwMI0IgxOJd0MOiucbQY2wlJw=
+github.com/dimfeld/httptreemux/v5 v5.3.0 h1:YPlS5UHDwed7EMnc2MfUP0mGvJqr3JYbfrC4pGgV8iw=
+github.com/dimfeld/httptreemux/v5 v5.3.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
The initial version of the webapi with,
- startup/shutdown logging
- configuration support
- single test 'ping' endpoint

The main.go startup code is based on the Arden Labs service project.